### PR TITLE
Invalid method name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [next]
+
+Fixed:
+* Invalid method name causing warning
+
 ## 1.0.0 - 28.01.2020
 
 Initial release

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -109,7 +109,7 @@ class Filesystem {
 			if ( ! isset( $arguments[0] ) ) {
 				$arguments[0] = '';
 			}
-			$arguments[0] = $this->base_path() . $arguments[0];
+			$arguments[0] = $this->path( $arguments[0] );
 		}
 
 		return call_user_func_array( [ $this->wp_filesystem, $method_name ], $arguments );


### PR DESCRIPTION
Not existing method name was used causing the following warning:
`( ! ) Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'WP_Filesystem_Direct' does not have a method 'base_path' in %project_dir%\vendor\micropackage\filesystem\src\Filesystem.php on line 115`