### PR TITLE
Feature/mkdir p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [next]
+
+Added:
+* mkdir_p method
+
 ## 1.0.0 - 28.01.2020
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [next]
 
 ### Added:
-* mkdir_p method
+* mkdir support for recursive dir creation when using Direct method.
 
 ### Fixed:
-* Invalid method name causing warning
+* Invalid method name causing warning.
 
 ## 1.0.0 - 28.01.2020
 

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -117,6 +117,45 @@ class Filesystem {
 	}
 
 	/**
+	 * Creates a directory recursively.
+	 *
+	 * @since [next]
+	 *
+	 * @param string     $path  Path for new directory.
+	 * @param int|false  $chmod Optional. The permissions as octal number (or false to skip chmod).
+	 *                          Default false.
+	 * @param string|int $chown Optional. A user name or number (or false to skip chown).
+	 *                          Default false.
+	 * @param string|int $chgrp Optional. A group name or number (or false to skip chgrp).
+	 *                          Default false.
+	 * @return bool True on success, false on failure.
+	 */
+	public function mkdir_p( $path, $chmod = false, $chown = false, $chgrp = false ) {
+		// Safe mode fails with a trailing slash under certain PHP versions.
+		$path = untrailingslashit( $path );
+		if ( empty( $path ) ) {
+			return false;
+		}
+
+		if ( ! $chmod ) {
+			$chmod = FS_CHMOD_DIR;
+		}
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( ! @mkdir( $path, $chmod, true ) ) {
+			return false;
+		}
+		$this->chmod( $path, $chmod );
+		if ( $chown ) {
+			$this->chown( $path, $chown );
+		}
+		if ( $chgrp ) {
+			$this->chgrp( $path, $chgrp );
+		}
+		return true;
+	}
+
+	/**
 	 * Changes the path to URL
 	 *
 	 * @since  1.0.0

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -58,7 +58,6 @@ class Filesystem {
 		'mtime',
 		'size',
 		'touch',
-		'mkdir',
 		'rmdir',
 		'dirlist',
 	];
@@ -119,18 +118,18 @@ class Filesystem {
 	/**
 	 * Creates a directory.
 	 *
+	 * @throws \Exception If recursive parameter used width filesystem method other than direct.
 	 * @since [next]
 	 *
-	 * @param string     $path      Path for new directory.
-	 * @param int|false  $chmod     Optional. The permissions as octal number (or false to skip chmod).
-	 *                              Default false.
-	 * @param string|int $chown     Optional. A user name or number (or false to skip chown).
-	 *                              Default false.
-	 * @param string|int $chgrp     Optional. A group name or number (or false to skip chgrp).
-	 *                              Default false.
-	 * @param bool       $recursive Whether to act recursively.
-	 * @return bool True on success, false on failure.
-	 * @throws \Exception If recursive parameter used width filesystem method other than direct.
+	 * @param  string     $path      Path for new directory.
+	 * @param  int|false  $chmod     Optional. The permissions as octal number (or false to skip chmod).
+	 *                               Default false.
+	 * @param  string|int $chown     Optional. A user name or number (or false to skip chown).
+	 *                               Default false.
+	 * @param  string|int $chgrp     Optional. A group name or number (or false to skip chgrp).
+	 *                               Default false.
+	 * @param  bool       $recursive Whether to act recursively.
+	 * @return bool                  True on success, false on failure.
 	 */
 	public function mkdir( $path, $chmod = false, $chown = false, $chgrp = false, $recursive = false ) {
 


### PR DESCRIPTION
Recursive method for creating directories.
Alternatively we could just overwrite the default `mkdir` method from WP_Filesystem to act recursively. The only difference here is the third param for native php `mkdir`.